### PR TITLE
Minor Grammatical Edits for better readability and clarify

### DIFF
--- a/src/lcia_methods/creating_new_impact_assessment_method.md
+++ b/src/lcia_methods/creating_new_impact_assessment_method.md
@@ -38,9 +38,9 @@ To do so:
 
 To see how to add impact categories in the impact assessment method window, characterization factors, etc, see the section below.
 
-### Creating and addung characterization factors
+### Creating and adding characterization factors
 
-In some methods maybe the characterization factors of an substance are missing. Hence you can add (or modify existing) characterization factors (CFs) in a LCIA method.
+In some methods maybe the characterization factors of a substance are missing. Hence you can add (or modify existing) characterization factors (CFs) in a LCIA method.
 
 To add a CF to a LCIA method:
 

--- a/src/lcia_methods/impact_methods_tab_contents.md
+++ b/src/lcia_methods/impact_methods_tab_contents.md
@@ -7,7 +7,7 @@ In openLCA versions from 1.x to the latest release, you could edit and create im
 
 In this section you can:
 
-Here you can view and modify the name of the methog, add a description, additional details or [tags](../cheat/tags.md), along with:
+Here you can view and modify the name of the method, add a description, additional details or [tags](../cheat/tags.md), along with:
 
 - Adding a source from the sources in the database. If unavailable, create a new source as described in "[Database elements](../databases/database_elements.md)".
 - Adding a code (i.e., a short name for the category, useful in result views).

--- a/src/prod_sys/tabs.md
+++ b/src/prod_sys/tabs.md
@@ -28,7 +28,7 @@ _Product system - General information tab_
 
 	
 At the product system level, you can add "[Parameters](../parameters/parameters.md)"
-by selecting the green "+" button at the end of the "Parameters" bar. It is not possible to create new parameters on the product system level, but you can add parameters that are already defined in processes You can customize the parameters you add by selecting one and then and change the amount, the uncertainty or the description. To select multiple parameters at once use your keyboard's "Shift" button. The amounts saved in a product system will override those saved in a process, for the given product system. However, the values saved in the process will not change.
+by selecting the green "+" button at the end of the "Parameters" bar. It is not possible to create new parameters on the product system level, but you can add parameters that are already defined in processes. You can customize the parameters you add by selecting one and then change the amount, the uncertainty or the description. To select multiple parameters at once use your keyboard's "Shift" button. The amounts saved in a product system will override those saved in a process, for the given product system. However, the values saved in the process will not change.
 
 </details>
 


### PR DESCRIPTION
The pages "Methods tab" and "Importing LCIA methods into openLCA" under LCIA methods and categories, as well as "Product system tabs" under Product Systems, contained minor grammatical errors and typos. I've corrected these issues, and the changes can be reviewed in the diff.

Thank you for creating and maintaining this excellent tool!